### PR TITLE
Enable IP anonymization by default in Google analytics

### DIFF
--- a/bundle/Resources/views/parts/ga_code.html.twig
+++ b/bundle/Resources/views/parts/ga_code.html.twig
@@ -12,12 +12,14 @@
                 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
                 ga('create', '{{ google_analytics_code|raw|escape('js') }}', 'auto');
+                ga('set', 'anonymizeIp', true);
                 ga('send', 'pageview');
             </script>
         {% else %}
             <script>
                 var _gaq = _gaq || [];
                 _gaq.push(['_setAccount', '{{ google_analytics_code|raw|escape('js') }}']);
+                _gaq.push(['_gat._anonymizeIp']);
                 _gaq.push(['_trackPageview']);
 
                 (function() {


### PR DESCRIPTION
IP anonymization should be enabled by default since this is a more common use case. Can't remember a single project in the past couple of years where we haven't copied this template to override it and enable the anonymizeIp, specially since the GDPR law was enforced in the EU.

I also don't think we should make this configurable in any way, if we have an edge case where the anonymizeIp needs to be removed, developer can always copy and override this template to remove it. But in 95% of the cases this will remove the need to do so.