### PR TITLE
NGSTACK-460 enable deeper levels of menu items

### DIFF
--- a/bundle/Menu/Factory/LocationFactory/ChildrenBuilder.php
+++ b/bundle/Menu/Factory/LocationFactory/ChildrenBuilder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\Menu\Factory\LocationFactory;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Knp\Menu\ItemInterface;
+use Netgen\EzPlatformSiteApi\API\FilterService;
+use Netgen\EzPlatformSiteApi\API\LoadService;
+use Netgen\EzPlatformSiteApi\API\Values\Content;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
+
+final class ChildrenBuilder
+{
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\LoadService
+     */
+    private $loadService;
+
+    /**
+     * @var \Netgen\EzPlatformSiteApi\API\FilterService
+     */
+    private $filterService;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        LoadService $loadService,
+        FilterService $filterService,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->loadService = $loadService;
+        $this->filterService = $filterService;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function buildChildItems(ItemInterface $item, Content $content): void
+    {
+        if (!$content->getField('parent_node')->isEmpty()) {
+            $childLocations = $this->buildChildrenFromRelatedParentNode($item, $content);
+        } elseif (!$content->getField('menu_items')->isEmpty()) {
+            $this->buildChildrenFromRelatedMenuItems($item, $content);
+        }
+    }
+
+    private function buildChildrenFromRelatedParentNode(ItemInterface $item, Content $content, ?Content $parentContent = null, int $currentDepth = 1): void
+    {
+        $childLocations = [];
+
+        $parentContent = $parentContent instanceof Content ? $parentContent : $content->getFieldRelation('parent_node');
+
+        if (!$parentContent instanceof Content) {
+            return;
+        }
+
+        if ($parentContent->mainLocation->invisible) {
+            $this->logger->error(sprintf('Menu item (#%s) has a related object (#%s) that is not visible.', $content->id, $parentContent->id));
+
+            return;
+        }
+
+        $criteria = [
+            new Criterion\Visibility(Criterion\Visibility::VISIBLE),
+            new Criterion\ParentLocationId($parentContent->mainLocation->id),
+        ];
+
+        if (!$content->getField('class_filter')->isEmpty() && !$content->getField('class_filter_type')->isEmpty()) {
+            /** @var \Netgen\Bundle\ContentTypeListBundle\Core\FieldType\ContentTypeList\Value $contentTypeFilter */
+            $contentTypeFilter = $content->getField('class_filter')->value;
+
+            /** @var \Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Value $filterType */
+            $filterType = $content->getField('class_filter_type')->value;
+
+            if ($filterType->identifiers[0] === 'include') {
+                $criteria[] = new Criterion\ContentTypeIdentifier($contentTypeFilter->identifiers);
+            } elseif ($filterType->identifiers[0] === 'exclude') {
+                $criteria[] = new Criterion\LogicalNot(
+                    new Criterion\ContentTypeIdentifier($contentTypeFilter->identifiers)
+                );
+            }
+        }
+
+        $query = new LocationQuery();
+        $query->filter = new Criterion\LogicalAnd($criteria);
+        $query->sortClauses = $parentContent->mainLocation->innerLocation->getSortClauses();
+
+        if (!$content->getField('limit')->isEmpty()) {
+            /** @var \eZ\Publish\Core\FieldType\Integer\Value $limit */
+            $limit = $content->getField('limit')->value;
+            if ($limit->value > 0) {
+                $query->limit = $limit->value;
+            }
+        }
+
+        $searchResult = $this->filterService->filterLocations($query);
+
+        $childLocations = array_map(
+            static function (SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $searchResult->searchHits
+        );
+
+        $maxDepth = 1;
+        if (!$content->getField('depth')->isEmpty()) {
+            $maxDepth = (int)$content->getFieldValue('depth')->text;
+        }
+
+        foreach ($childLocations as $location) {
+            $childItem = $item->addChild(null, ['ezlocation' => $location]);
+            if ($currentDepth <= $maxDepth) {
+                $this->buildChildrenFromRelatedParentNode($childItem, $content, $location->content, $currentDepth + 1);
+            }
+        }
+    }
+
+    private function buildChildrenFromRelatedMenuItems(ItemInterface $item, Content $content): void
+    {
+        $childLocations = [];
+
+        foreach ($content->getField('menu_items')->value->destinationLocationIds as $locationId) {
+            if (empty($locationId)) {
+                $this->logger->error(sprintf('Empty location ID in RelationList field "%s" for content #%s', 'menu_items', $content->id));
+
+                continue;
+            }
+
+            try {
+                $childLocations[] = $this->loadService->loadLocation($locationId);
+            } catch (Throwable $t) {
+                $this->logger->error($t->getMessage());
+
+                continue;
+            }
+        }
+
+        foreach ($childLocations as $location) {
+            $item->addChild(null, ['ezlocation' => $location]);
+        }
+    }
+}

--- a/bundle/Menu/Factory/LocationFactory/ChildrenBuilder.php
+++ b/bundle/Menu/Factory/LocationFactory/ChildrenBuilder.php
@@ -16,22 +16,22 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 
-final class ChildrenBuilder
+class ChildrenBuilder
 {
     /**
      * @var \Netgen\EzPlatformSiteApi\API\LoadService
      */
-    private $loadService;
+    protected $loadService;
 
     /**
      * @var \Netgen\EzPlatformSiteApi\API\FilterService
      */
-    private $filterService;
+    protected $filterService;
 
     /**
      * @var \Psr\Log\LoggerInterface
      */
-    private $logger;
+    protected $logger;
 
     public function __construct(
         LoadService $loadService,
@@ -52,7 +52,7 @@ final class ChildrenBuilder
         }
     }
 
-    private function buildChildrenFromRelatedParentNode(ItemInterface $item, Content $content, ?Content $parentContent = null, int $currentDepth = 1): void
+    protected function buildChildrenFromRelatedParentNode(ItemInterface $item, Content $content, ?Content $parentContent = null, int $currentDepth = 1): void
     {
         $childLocations = [];
 
@@ -123,7 +123,7 @@ final class ChildrenBuilder
         }
     }
 
-    private function buildChildrenFromRelatedMenuItems(ItemInterface $item, Content $content): void
+    protected function buildChildrenFromRelatedMenuItems(ItemInterface $item, Content $content): void
     {
         $childLocations = [];
 

--- a/bundle/Resources/config/menu.yml
+++ b/bundle/Resources/config/menu.yml
@@ -48,15 +48,22 @@ services:
         class: Netgen\Bundle\SiteBundle\Menu\Factory\LocationFactory\MenuItemExtension
         public: false
         arguments:
-            - "@netgen.ezplatform_site.load_service"
-            - "@netgen.ezplatform_site.filter_service"
             - "@router"
             - "@request_stack"
             - "@ezpublish.config.resolver"
+            - "@ngsite.menu.factory.location.extension.children_builder"
             - "@?logger"
         tags:
             - { name: ngsite.menu.factory.location.extension, priority: 0 }
             - { name: monolog.logger, channel: ngsite }
+
+    ngsite.menu.factory.location.extension.children_builder:
+        class: Netgen\Bundle\SiteBundle\Menu\Factory\LocationFactory\ChildrenBuilder
+        public: false
+        arguments:
+            - "@netgen.ezplatform_site.load_service"
+            - "@netgen.ezplatform_site.filter_service"
+            - "@?logger"
 
     ngsite.menu.main_menu:
         class: Knp\Menu\MenuItem


### PR DESCRIPTION
DB changes:
* added new `text line` field
* field name: `Max depth`
* field identifier: `depth`
* position: `8`

Changes made for testing:
* created new landing page under `healthy eating` (`/ngadminui/fit-healthy/healthy-eating`)
* moved three blog posts from their original location (`/ngadminui/fit-healthy/healthy-eating`) to below new landing page
* created new menu item `http://media-site.dev.php74.ez/ngadminui/media/menu-items/test-menu-item`, with parent node set to `Healthy eating`, max depth set to 3, class filter set to `include` landing pages and blog posts
* replace existing item in site info main menu which points to `Healthy eating` with new menu item.