### PR TITLE
Add command for changing Content always-available state

### DIFF
--- a/bundle/Command/UpdateContentAlwaysAvailableCommand.php
+++ b/bundle/Command/UpdateContentAlwaysAvailableCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\Command;
+
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Repository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class UpdateContentAlwaysAvailableCommand extends Command
+{
+    protected static $defaultDescription = 'Update always-available state for the given Content item(s)';
+
+    private Repository $repository;
+    private ContentService $contentService;
+
+    public function __construct(
+        Repository $repository,
+        ContentService $contentService
+    ) {
+        parent::__construct();
+
+        $this->repository = $repository;
+        $this->contentService = $contentService;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'content_ids',
+                InputArgument::REQUIRED,
+                'Content IDs (comma delimited)',
+            )
+            ->addArgument(
+                'always-available',
+                InputArgument::OPTIONAL,
+                'Always-available state (true/false or 1/0)',
+                true
+            );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln(
+            '<info>This command updates Content item(s) always-available flag.</info>'
+        );
+
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('Continue with this action? (Y/n) ', true);
+
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('<info>Aborted.</info>');
+
+            return Command::SUCCESS;
+        }
+
+        $types = $input->getArgument('content_ids');
+        $contentIds = array_map('intval', array_map('trim', explode(',', $types)));
+        $alwaysAvailableState = $this->resolveAlwaysAvailableState($input->getArgument('always-available'));
+
+        foreach ($contentIds as $contentId) {
+            $contentInfo = $this->repository->sudo(
+                function () use ($contentId) {
+                    return $this->contentService->loadContentInfo($contentId);
+                }
+            );
+
+            $struct = $this->contentService->newContentMetadataUpdateStruct();
+            $struct->alwaysAvailable = $alwaysAvailableState;
+
+            $this->repository->sudo(
+                function () use ($contentInfo, $struct) {
+                    $this->contentService->updateContentMetadata($contentInfo, $struct);
+                }
+            );
+        }
+
+        $output->writeln('<info>Done.</info>');
+
+        return self::SUCCESS;
+    }
+
+    private function resolveAlwaysAvailableState($argument): bool
+    {
+        if ($argument === 'false') {
+            return false;
+        }
+
+        return (bool) $argument;
+    }
+}

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -7,6 +7,14 @@ services:
         tags:
             - { name: console.command, command: 'ngsite:content-type:move' }
 
+    ngsite.command.content.update_always_available:
+        class: Netgen\Bundle\SiteBundle\Command\UpdateContentAlwaysAvailableCommand
+        arguments:
+            - "@ibexa.api.repository"
+            - "@ibexa.api.service.content"
+        tags:
+            - { name: console.command, command: 'ngsite:content:update-always-available' }
+
     ngsite.command.update_publish_date:
         class: Netgen\Bundle\SiteBundle\Command\UpdatePublishDateCommand
         arguments:

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -1,5 +1,5 @@
 services:
-    ngsite.command.move_content_type:
+    ngsite.command.content_type.move:
         class: Netgen\Bundle\SiteBundle\Command\MoveContentTypeCommand
         arguments:
             - "@ibexa.api.repository"


### PR DESCRIPTION
Another command to provide functionality missing in the new Ibexa Admin UI.

Example call:

```console
bin/console ngsite:content:update-always-available 235,236 false
```