### PR TITLE
Update XSLT namespaces

### DIFF
--- a/bundle/Resources/docbook/edit/core.xsl
+++ b/bundle/Resources/docbook/edit/core.xsl
@@ -3,8 +3,8 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:docbook="http://docbook.org/ns/docbook"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+    xmlns:ezxhtml="http://ibexa.co/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ibexa.co/xmlns/ezpublish/docbook/custom"
     exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
     version="1.0">
     <xsl:output indent="yes" encoding="UTF-8"/>

--- a/bundle/Resources/docbook/output/core.xsl
+++ b/bundle/Resources/docbook/output/core.xsl
@@ -3,8 +3,8 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:docbook="http://docbook.org/ns/docbook"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+    xmlns:ezxhtml="http://ibexa.co/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ibexa.co/xmlns/ezpublish/docbook/custom"
     exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
     version="1.0">
     <xsl:output indent="yes" encoding="UTF-8"/>


### PR DESCRIPTION
XML namespace values were changed in https://github.com/ibexa/fieldtype-richtext/pull/31, so we need to update as the conversion is a bit woozy now.