### PR TITLE
NGSTACK-630: override BinaryFormMapper to properly handle null value

### DIFF
--- a/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\ContentForms\FieldType\Mapper;
+
+use Ibexa\ContentForms\FieldType\DataTransformer\BinaryFileValueTransformer;
+use Ibexa\ContentForms\Form\Type\FieldType\BinaryFileFieldType;
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface;
+use Ibexa\Contracts\Core\Repository\FieldTypeService;
+use Ibexa\Core\FieldType\BinaryFile\Value;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Overridden to properly handle null value for information collection.
+ */
+class BinaryFileFormMapper implements FieldValueFormMapperInterface
+{
+    private FieldTypeService $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     */
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
+    {
+        $fieldDefinition = $data->fieldDefinition;
+        $formConfig = $fieldForm->getConfig();
+        $fieldType = $this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier);
+        $value = $data->value;
+
+        if ($value === null) {
+            $value = $fieldType->getEmptyValue();
+        }
+
+        $fieldForm
+            ->add(
+                $formConfig->getFormFactory()->createBuilder()
+                    ->create(
+                        'value',
+                        BinaryFileFieldType::class,
+                        [
+                            'required' => $fieldDefinition->isRequired,
+                            'label' => $fieldDefinition->getName(),
+                        ],
+                    )
+                    ->addModelTransformer(
+                        new BinaryFileValueTransformer($fieldType, $value, Value::class),
+                    )
+                    ->setAutoInitialize(false)
+                    ->getForm(),
+            );
+    }
+}

--- a/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
@@ -32,11 +32,7 @@ class BinaryFileFormMapper implements FieldValueFormMapperInterface
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
         $fieldType = $this->fieldTypeService->getFieldType($fieldDefinition->fieldTypeIdentifier);
-        $value = $data->value;
-
-        if ($value === null) {
-            $value = $fieldType->getEmptyValue();
-        }
+        $value = $data->value ?? $fieldType->getEmptyValue();
 
         $fieldForm
             ->add(

--- a/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
+++ b/bundle/ContentForms/FieldType/Mapper/BinaryFileFormMapper.php
@@ -24,9 +24,6 @@ class BinaryFileFormMapper implements FieldValueFormMapperInterface
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    /**
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     */
     public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -268,6 +268,11 @@ services:
         tags:
             - { name: data_collector, template: '@NetgenSite/data_collector/git.html.twig', id: ngsite.data_collector.git }
 
+    Netgen\Bundle\SiteBundle\ContentForms\FieldType\Mapper\BinaryFileFormMapper:
+        decorates: Ibexa\ContentForms\FieldType\Mapper\BinaryFileFormMapper
+        arguments:
+            - '@ibexa.api.service.field_type'
+
 #    Custom user context hash providers are disabled by default.
 #    Enable them in your project if needed by copying one of the
 #    following service definitions.

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -268,7 +268,7 @@ services:
         tags:
             - { name: data_collector, template: '@NetgenSite/data_collector/git.html.twig', id: ngsite.data_collector.git }
 
-    Netgen\Bundle\SiteBundle\ContentForms\FieldType\Mapper\BinaryFileFormMapper:
+    ngsite.content_forms.field_type.binary_file_form_mapper:
         decorates: Ibexa\ContentForms\FieldType\Mapper\BinaryFileFormMapper
         arguments:
             - '@ibexa.api.service.field_type'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ibexa/core": "^4.0",
-        "ibexa/content-forms": "*",
+        "ibexa/content-forms": "^4.0",
         "symfony/mailer": "^5.4",
         "symfony/polyfill-php80": "^1.22",
         "netgen/ibexa-forms-bundle": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ibexa/core": "^4.0",
+        "ibexa/content-forms": "*",
         "symfony/mailer": "^5.4",
         "symfony/polyfill-php80": "^1.22",
         "netgen/ibexa-forms-bundle": "^4.0",


### PR DESCRIPTION
See original here: https://github.com/ibexa/content-forms/blob/main/src/lib/FieldType/Mapper/BinaryFileFormMapper.php

Not entirely sure why it was implemented like that, I think it's probably meant to edit the existing content, which is missing when handling info collection. So not intended for info collection and not sure if we can get this upstream.