### PR TITLE
Implement dynamic honeypot field

### DIFF
--- a/bundle/Controller/InfoCollection/ProxyFormHandler.php
+++ b/bundle/Controller/InfoCollection/ProxyFormHandler.php
@@ -16,7 +16,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -110,11 +109,8 @@ class ProxyFormHandler extends Controller
         $validCaptcha = $captcha->isValid($request);
 
         if ($formSubmitted && $form->isValid() && $validCaptcha) {
-            if ($this->isHoneypotEmpty($form)) {
-                $event = new InformationCollected($form->getData(), []);
-
-                $this->eventDispatcher->dispatch($event, Events::INFORMATION_COLLECTED);
-            }
+            $event = new InformationCollected($form->getData(), [], ['form' => $form]);
+            $this->eventDispatcher->dispatch($event, Events::INFORMATION_COLLECTED);
 
             $isCollected = true;
         }
@@ -133,16 +129,5 @@ class ProxyFormHandler extends Controller
             'is_collected' => $isCollected,
             'form' => $form->createView(),
         ];
-    }
-
-    private function isHoneypotEmpty(FormInterface $form): bool
-    {
-        if (!$form->has('sender_middle_name')) {
-            return true;
-        }
-
-        $honeypot = $form->get('sender_middle_name');
-
-        return $honeypot->getData() === '';
     }
 }

--- a/bundle/EventListener/HoneypotListener.php
+++ b/bundle/EventListener/HoneypotListener.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\EventListener;
+
+use Netgen\InformationCollection\API\Events;
+use Netgen\InformationCollection\API\Exception\MissingAdditionalParameterException;
+use Netgen\InformationCollection\API\Value\Event\InformationCollected;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This listener runs before any other listener attached to INFORMATION_COLLECTED
+ * event. In case of honeypot field being filled with any content, it will simply
+ * disable propagation of the event to other listeners which perform actions like
+ * writing to the database, emailing and so on.
+ *
+ * Effectively, the collection submission process will complete as normal, except
+ * nothing will be written to the database nor any emails will be sent. The user
+ * will not have any feedback that anything was out of the ordinary, which is
+ * the point of the honeypot.
+ */
+class HoneypotListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::INFORMATION_COLLECTED => ['onInformationCollected', 255],
+        ];
+    }
+
+    public function onInformationCollected(InformationCollected $event): void
+    {
+        $content = $event->getContent();
+
+        if (!isset($content->fields['honeypot_field_name'])) {
+            return;
+        }
+
+        $honeyPotFieldName = $content->getFieldValue('honeypot_field_name')->text;
+        if ($honeyPotFieldName === '') {
+            return;
+        }
+
+        try {
+            /** @var \Symfony\Component\Form\FormInterface $form */
+            $form = $event->getAdditionalParameter('form');
+        } catch (MissingAdditionalParameterException $e) {
+            return;
+        }
+
+        if ($form->get($honeyPotFieldName)->get('value')->getData()->text !== '') {
+            $event->stopPropagation();
+        }
+    }
+}

--- a/bundle/InfoCollection/Form/Extension/HoneypotExtension.php
+++ b/bundle/InfoCollection/Form/Extension/HoneypotExtension.php
@@ -18,9 +18,31 @@ class HoneypotExtension extends AbstractTypeExtension
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var \Netgen\InformationCollection\API\Value\InformationCollectionStruct $struct */
+        $struct = $options['data'];
+        $content = $struct->getContent();
+
+        if (!isset($content->fields['honeypot_field_name'])) {
+            return;
+        }
+
+        $honeyPotFieldName = $content->getFieldValue('honeypot_field_name')->text;
+        if ($honeyPotFieldName === '') {
+            return;
+        }
+
+        $honeyPotFieldLabel = '';
+        if (isset($content->fields['honeypot_field_label'])) {
+            $honeyPotFieldLabel = $content->getFieldValue('honeypot_field_label')->text;
+        }
+
         $builder->add(
-            'sender_middle_name',
+            $honeyPotFieldName,
             HoneypotType::class,
+            [
+                'mapped' => false,
+                'label' => $honeyPotFieldLabel,
+            ],
         );
     }
 }

--- a/bundle/InfoCollection/Form/Type/HoneypotType.php
+++ b/bundle/InfoCollection/Form/Type/HoneypotType.php
@@ -21,9 +21,8 @@ class HoneypotType extends AbstractType
             'value',
             TextLineFieldType::class,
             [
-                'label' => 'ngsite.collected_info.contact_form.middle_name',
-                'translation_domain' => 'messages',
-                'empty_data' => '',
+                'label' => $options['label'],
+                'translation_domain' => $options['translation_domain'],
             ],
         );
     }

--- a/bundle/Resources/config/event_listeners.yaml
+++ b/bundle/Resources/config/event_listeners.yaml
@@ -64,3 +64,8 @@ services:
         parent: ngsite.listener.user
         tags:
             - { name: kernel.event_subscriber }
+
+    ngsite.listener.honeypot:
+        class: Netgen\Bundle\SiteBundle\EventListener\HoneypotListener
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
This implements a dynamic honeypot field.

Instead of using a hardcoded input in the form, this takes the name of the input from the content field. An additional field can be used for label.