### PR TITLE
Pass new argument to the handler

### DIFF
--- a/bundle/Controller/InfoCollection/ProxyFormHandler.php
+++ b/bundle/Controller/InfoCollection/ProxyFormHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Netgen\Bundle\SiteBundle\Controller\InfoCollection;
 
 use Netgen\Bundle\IbexaSiteApiBundle\View\ContentView;
+use Netgen\Bundle\InformationCollectionBundle\Ibexa\ContentForms\InformationCollectionType;
 use Netgen\Bundle\SiteBundle\Controller\Controller;
 use Netgen\Bundle\SiteBundle\InfoCollection\RefererResolver;
 use Netgen\IbexaSiteApi\API\Values\Location;
@@ -99,6 +100,7 @@ class ProxyFormHandler extends Controller
         $form = $this->handler->getForm(
             $location->innerLocation->getContent(),
             $location->innerLocation,
+            $request,
         );
 
         $isCollected = false;


### PR DESCRIPTION
This makes possible to have multiple instances of the same form without ID conflicts.

See https://github.com/netgen/NetgenInformationCollectionBundle/pull/82