### PR TITLE
NGSTACK-901 implement decorator service for variation path generator

### DIFF
--- a/bundle/Core/Imagine/VariationPathGenerator/WebpFormatVariationPathGenerator.php
+++ b/bundle/Core/Imagine/VariationPathGenerator/WebpFormatVariationPathGenerator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\Core\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+
+/**
+ * Decorates VariationPathGenerator with .webp extension if image variation is configured for this format.
+ */
+final class WebpFormatVariationPathGenerator implements VariationPathGenerator
+{
+    private VariationPathGenerator $innerVariationPathGenerator;
+
+    private FilterConfiguration $filterConfiguration;
+
+    public function __construct(
+        VariationPathGenerator $innerVariationPathGenerator,
+        FilterConfiguration $filterConfiguration
+    ) {
+        $this->innerVariationPathGenerator = $innerVariationPathGenerator;
+        $this->filterConfiguration = $filterConfiguration;
+    }
+
+    public function getVariationPath($originalPath, $filter): string
+    {
+        $variationPath = $this->innerVariationPathGenerator->getVariationPath($originalPath, $filter);
+        $filterConfig = $this->filterConfiguration->get($filter);
+
+        if (!isset($filterConfig['format']) || $filterConfig['format'] !== 'webp') {
+            return $variationPath;
+        }
+
+        $info = pathinfo($originalPath);
+
+        if(empty($info['extension'])){
+            return $variationPath . '.webp';
+        }
+
+        return preg_replace("/\.{$info['extension']}$/", '.webp', $variationPath);
+    }
+}

--- a/bundle/DependencyInjection/Compiler/WebpFormatVariationPathGeneratorDecoratorPass.php
+++ b/bundle/DependencyInjection/Compiler/WebpFormatVariationPathGeneratorDecoratorPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\SiteBundle\DependencyInjection\Compiler;
+
+use Netgen\Bundle\SiteBundle\Core\Imagine\VariationPathGenerator\WebpFormatVariationPathGenerator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class WebpFormatVariationPathGeneratorDecoratorPass implements CompilerPassInterface
+{
+    /**
+     * Overrides the IO resolver to disable generating absolute URIs to images.
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has('ezpublish.image_alias.variation_path_generator')) {
+
+            $container->register(
+                'ezpublish.image_alias.webp_variation_path_generator_decorator',
+                WebpFormatVariationPathGenerator::class)
+                ->setDecoratedService('ezpublish.image_alias.variation_path_generator')
+                ->addArgument(new Reference('ezpublish.image_alias.webp_variation_path_generator_decorator.inner'))
+                ->addArgument(new Reference('liip_imagine.filter.configuration'));
+        }
+    }
+}

--- a/bundle/NetgenSiteBundle.php
+++ b/bundle/NetgenSiteBundle.php
@@ -20,5 +20,6 @@ class NetgenSiteBundle extends Bundle
         $container->addCompilerPass(new Compiler\LocationFactoryPass());
         $container->addCompilerPass(new Compiler\AsseticPass());
         $container->addCompilerPass(new Compiler\IoStorageAllowListPass());
+        $container->addCompilerPass(new Compiler\WebpFormatVariationPathGeneratorDecoratorPass());
     }
 }


### PR DESCRIPTION
Implement decorator service for variation path generator which will replace file extension with webp, if image variation is configured for this format.

The implementation is heavily based on https://github.com/ezsystems/ezplatform-kernel/pull/361, except we don't just append ".webp" on full generated image path, but instead replace the generated file extension with 'webp'.

The reason for this is keeping backward compatibility with eZ Publish legacy kernel (used in Netgen Admin UI). Legacy image aliases can be configured to be generated in specific format/mime type (i.e. original image is JPG but variation will be generated as WebP). But in this case, the alias filenames will always contain only one file extension, the one specified by the alias mime type. So this should prevent duplicate images being generated on the file system, both legacy and Symfony variation generators will use same alias path patterns.

This decorator serves purpose only for the ezsystems/ezpublish-kernel with or without the legacy-based admin. 
Later kernel versions (both ezplatform-kernel and ibexa) already contain this decorator service by default.