### PR TITLE
NGSTACK-918 adjust ShortcutExtension to work with new link field (ngenhancedlink)

### DIFF
--- a/bundle/Menu/Factory/LocationFactory/ShortcutExtension.php
+++ b/bundle/Menu/Factory/LocationFactory/ShortcutExtension.php
@@ -98,7 +98,7 @@ final class ShortcutExtension implements ExtensionInterface
             $item->setLinkAttribute('title', $link->label);
 
             if (!$content->getField('use_shortcut_name')->value->bool) {
-                $item->setLabel($urlValue->text);
+                $item->setLabel($link->label);
             }
         }
     }

--- a/bundle/Resources/config/menu.yaml
+++ b/bundle/Resources/config/menu.yaml
@@ -33,6 +33,7 @@ services:
         arguments:
             - "@router"
             - "@request_stack"
+            - "@netgen.ibexa_site_api.load_service"
             - "@?logger"
         tags:
             - { name: ngsite.menu.factory.location.extension, priority: 0 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/mailer": "^5.4",
         "netgen/ibexa-forms-bundle": "^4.0",
         "netgen/ibexa-site-api": "^6.1",
+        "netgen/ibexa-fieldtype-enhanced-link": "^1.1",
         "netgen/information-collection-bundle": "^3.0",
         "netgen/siteaccess-routes-bundle": "^3.0",
         "netgen/content-type-list-bundle": "^3.0",


### PR DESCRIPTION
Code does not reflect current ng_shortcut content type. Referencing 'url', 'related_content' and other non-existing fields will break the site if ng_shortcut item is added in any of the menus