### PR TITLE
Remove redundant symfony/polyfill-php84 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "ibexa/core": "^5.0",
         "ibexa/content-forms": "^5.0",
         "symfony/mailer": "^7.3",
-        "symfony/polyfill-php84": "^1.33",
         "netgen/ibexa-forms-bundle": "^5.0",
         "netgen/ibexa-site-api": "^7.0",
         "netgen/ibexa-search-extra": "^4.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php84`, but also `php: ^8.4`, so the polyfill requirement doesn't seem necessary anymore?